### PR TITLE
do not ignore linked files

### DIFF
--- a/T4MVCHostMvcApp.Tests/T4MVCTest.cs
+++ b/T4MVCHostMvcApp.Tests/T4MVCTest.cs
@@ -292,6 +292,12 @@ namespace T4MVCHostMvcApp.Tests
             Assert.AreEqual("/Areas/FeatureFolderArea/SharedViews/SharedView.txt", Links.Areas.FeatureFolderArea.SharedViews.SharedView_txt);
         }
 
+        [TestMethod()]
+        public void TestLinkedView()
+        {
+            Assert.AreEqual("~/Views/Home/SomeLinkedFile.txt", MVC.Home.Views.SomeLinkedFile);
+        }
+
         // ROUTE VALUES TESTS
 
         [TestMethod()]

--- a/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
@@ -266,6 +266,7 @@ namespace T4MVCHostMvcApp.Controllers
                 public readonly string Qqq = "Qqq";
                 public readonly string QqQ = "QqQ";
                 public readonly string Qqq_txt3 = "Qqq_txt3";
+                public readonly string SomeLinkedFile = "SomeLinkedFile";
             }
             public readonly string _7_Some_Home_View_Hello = "~/Views/Home/7 Some Home.View-Hello.txt";
             public readonly string About = "~/Views/Home/About.aspx";
@@ -274,6 +275,7 @@ namespace T4MVCHostMvcApp.Controllers
             public readonly string Qqq = "~/Views/Home/Qqq.txt";
             public readonly string QqQ = "~/Views/Home/QqQ.txt2";
             public readonly string Qqq_txt3 = "~/Views/Home/Qqq.txt3";
+            public readonly string SomeLinkedFile = "~/Views/Home/SomeLinkedFile.txt";
             static readonly _defaultClass s_default = new _defaultClass();
             public _defaultClass @default { get { return s_default; } }
             [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1467,8 +1467,6 @@ static string GetVirtualPath(ProjectItem item)
         {
             return null;
         }
-        if (!fileFullPath.StartsWith(AppRoot, StringComparison.OrdinalIgnoreCase))
-            return null;
     }
 
     // Make a virtual path from the physical path

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1456,9 +1456,20 @@ static string GetVirtualPath(ProjectItem item)
 {
     string fileFullPath = item.get_FileNames(0);
 
-    // Ignore files that are not under the app root (e.g. they could be linked files)
+    // update full path for files that are not under the app root (e.g. they could be linked files)
     if (!fileFullPath.StartsWith(AppRoot, StringComparison.OrdinalIgnoreCase))
-        return null;
+    {
+        try
+        {
+            fileFullPath = ((ProjectItem)item.Collection.Parent).Properties.Item("FullPath").Value.ToString() + item.Name;
+        }
+        catch
+        {
+            return null;
+        }
+        if (!fileFullPath.StartsWith(AppRoot, StringComparison.OrdinalIgnoreCase))
+            return null;
+    }
 
     // Make a virtual path from the physical path
     return "~/" + fileFullPath.Substring(AppRoot.Length).Replace('\\', '/');


### PR DESCRIPTION
Fix 3.8.2 (3-10-2014) ignores linked files because of inability
obtaining full (local) path of linked item. This is a
solution to that problem.
