### PR TITLE
Added AssetsNamespace to allow the existance of such a folder in the project...

### DIFF
--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1109,7 +1109,8 @@ void ProcessBundleFilesRecursive(ProjectItem projectItem, string path, HashSet<S
     // This HashSet is to guarantee uniqueness of our direct children
     // We add our own name to it to avoid class name conflicts (http://mvccontrib.codeplex.com/workitem/7153)
     var childrenNameSet = new HashSet<String>(StringComparer.OrdinalIgnoreCase);
-    childrenNameSet.Add("Assets");
+
+    childrenNameSet.Add(settings.AssetsNamespace);
     childrenNameSet.Add(name);
 
     var files = new List<ProjectItem>();
@@ -1150,7 +1151,7 @@ void BuildBundleConstants(List<ProjectItem> projectItems, string path, HashSet<S
 {
     PushIndent("    ");
 #>
-public static class Assets
+public static class <#= settings.AssetsNamespace #>
 {
 <#+
     PushIndent("    ");
@@ -2157,6 +2158,7 @@ class MvcSettings : XmlSettings
         this.SupportAsyncActions = false;
         this.UseLowercaseRoutes = false;
         this.LinksNamespace = "Links";
+		this.AssetsNamespace = "Assets";
         this.AddTimestampToStaticLinks = false;
         this.StaticFilesFolders = new XmlStringArray(new string[] {
             "Scripts",
@@ -2226,6 +2228,10 @@ class MvcSettings : XmlSettings
 
     [System.ComponentModel.Description("The namespace that the links are generated in (e.g. \"Links\", as in Links.Content.nerd_jpg)")]
     public string LinksNamespace { get; set; }
+
+	[System.ComponentModel.Description("The namespace that raw URLS used for bundles are generated")]
+    public string AssetsNamespace { get; set; }
+
 
     [System.ComponentModel.Description("If true, links to static files include a query string containing the file's last change time.\r\nThis way, when the static file changes, the link changes and guarantees that the client will re-request the resource.\r\ne.g. when true, the link looks like: \"/Content/nerd.jpg?2009-09-04T12:25:48\"\r\nSee http://mvccontrib.codeplex.com/workitem/7163 for potential issues with this feature")]
     public bool AddTimestampToStaticLinks { get; set; }

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt.settings.xml
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt.settings.xml
@@ -46,6 +46,8 @@ This breaks the Go To Definition function for async actions.-->
   <UseLowercaseRoutes>False</UseLowercaseRoutes>
   <!--The namespace that the links are generated in (e.g. "Links", as in Links.Content.nerd_jpg)-->
   <LinksNamespace>Links</LinksNamespace>
+  <!-- The namespace that raw URLS used for bundles are generated -->
+  <AssetsNamespace>Assets</AssetsNamespace>
   <!--If true, links to static files include a query string containing the file's last change time.
 This way, when the static file changes, the link changes and guarantees that the client will re-request the resource.
 e.g. when true, the link looks like: "/Content/nerd.jpg?2009-09-04T12:25:48"


### PR DESCRIPTION
In our project, we have an Assets folder in the solution that contains the css/less files, etc. When I wanted to include that in the Content generation used by T4MVC, I got:

Error   7   'Assets': member names cannot be the same as their enclosing type

So, I wanted to add a setting for the hardcoded string to enable people who have such a folder to rename it.
