### PR TITLE
Added support for TypeScript JSX files.

### DIFF
--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1301,6 +1301,16 @@ if (!settings.ExcludedStaticFileExtensions.Any(extension => projectItem.Name.End
     public static readonly string <#=name#> = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(URLPATH + "/<#=minifiedName#>") ? Url("<#=minifiedName#>") : Url("<#=tsJavascriptName#>");
 <#+}  #>
 <#+}
+    // if it's a Typescript JSX file
+    else if (projectItem.Name.EndsWith(".tsx")) {
+        string tsJavascriptName =  projectItem.Name.Replace(".tsx", ".js");
+        string minifiedName = projectItem.Name.Replace(".tsx", ".min.js");
+        if (AddTimestampToStaticLink(projectItem)) { #>
+    public static readonly string <#=name#> = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(URLPATH + "/<#=minifiedName#>") ? Url("<#=minifiedName#>")+"?"+T4MVCHelpers.TimestampString(URLPATH + "/<#=minifiedName#>") : Url("<#=tsJavascriptName#>")+"?"+T4MVCHelpers.TimestampString(URLPATH + "/<#=tsJavascriptName#>");
+        <#+} else {#>
+    public static readonly string <#=name#> = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(URLPATH + "/<#=minifiedName#>") ? Url("<#=minifiedName#>") : Url("<#=tsJavascriptName#>");
+<#+}  #>
+<#+}
     // if it's a non-minified javascript file
     else if (projectItem.Name.EndsWith(".js") && !projectItem.Name.EndsWith(".min.js")) {
         string minifiedName = projectItem.Name.Replace(".js", ".min.js");


### PR DESCRIPTION
> In 1.6, we’ve introduced a new .tsx file extension.  This extension does two things: it enables JSX inside of TypeScript files, and it makes the new ‘as’ operator the default way to cast.  With this, we’ve added full support for working with React/JSX in TypeScript in a type-safe way. 

http://blogs.msdn.com/b/typescript/archive/2015/09/02/announcing-typescript-1-6-beta-react-jsx-better-error-checking-and-more.aspx
