### PR TITLE
Exclude default values from Route Values

### DIFF
--- a/T4MVCExtensions/T4MVCExtensions.nuspec
+++ b/T4MVCExtensions/T4MVCExtensions.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>T4MVCExtensions</id>
-    <version>3.15.4</version>
+    <version>3.15.5</version>
     <authors>$author$</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>

--- a/T4MVCHostMvcApp.Tests/T4MVCTest.cs
+++ b/T4MVCHostMvcApp.Tests/T4MVCTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Threading;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -371,6 +372,38 @@ namespace T4MVCHostMvcApp.Tests
             var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithOptionalParamDefaultingToNull(null);
 
             TestNoRouteValue(actionRes, "n");
+        }
+
+        [TestMethod()]
+        public void TestOptionalParamWithDefaultValue()
+        {
+            var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithOptionalParamDefaultingToDefaultValue(default(CancellationToken));
+
+            TestNoRouteValue(actionRes, "cancellationToken");
+        }
+
+        [TestMethod()]
+        public void TestOptionalParamWithDefaultValueContainingSpaces()
+        {
+            var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithOptionalParamDefaultingToDefaultValueWithSpaces(default(CancellationToken));
+
+            TestNoRouteValue(actionRes, "cancellationToken");
+        }
+
+        [TestMethod()]
+        public void TestOptionalParamWithDefaultValueAndFullyQualifiedTypeName()
+        {
+            var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName(default(CancellationToken));
+
+            TestNoRouteValue(actionRes, "cancellationToken");
+        }
+
+        [TestMethod()]
+        public void TestOptionalParamWithConstructedDefaultValue()
+        {
+            var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithOptionalParamDefaultingToConstructedDefaultValue(default(CancellationToken));
+
+            TestNoRouteValue(actionRes, "cancellationToken");
         }
 
         [TestMethod()]

--- a/T4MVCHostMvcApp.Tests/T4MVCTest.cs
+++ b/T4MVCHostMvcApp.Tests/T4MVCTest.cs
@@ -334,8 +334,8 @@ namespace T4MVCHostMvcApp.Tests
             var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithAllOptionalParams();
 
             TestAreaControllerActionNames(actionRes, "", "Home", "ActionWithAllOptionalParams");
-            TestRouteValue(actionRes, "someString", "Hello");
-            TestRouteValue(actionRes, "n", 5);
+            TestNoRouteValue(actionRes, "someString");
+            TestNoRouteValue(actionRes, "n");
         }
 
         [TestMethod()]
@@ -350,10 +350,19 @@ namespace T4MVCHostMvcApp.Tests
         [TestMethod()]
         public void TestOptionalParamWhenNotPassingItIn()
         {
+            var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithSomeOptionalParams("Hello", 7);
+
+            TestRouteValue(actionRes, "someString", "Hello");
+            TestRouteValue(actionRes, "n", 7);
+        }
+
+        [TestMethod()]
+        public void TestOptionalParamWhenPassingInNonDefaultValue()
+        {
             var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithSomeOptionalParams("Hello");
 
             TestRouteValue(actionRes, "someString", "Hello");
-            TestRouteValue(actionRes, "n", 5);
+            TestNoRouteValue(actionRes, "n");
         }
 
         [TestMethod()]
@@ -361,7 +370,7 @@ namespace T4MVCHostMvcApp.Tests
         {
             var actionRes = (IT4MVCActionResult)MVC.Home.ActionWithOptionalParamDefaultingToNull(null);
 
-            TestRouteValue(actionRes, "n", null);
+            TestNoRouteValue(actionRes, "n");
         }
 
         [TestMethod()]

--- a/T4MVCHostMvcApp/Controllers/HomeController.cs
+++ b/T4MVCHostMvcApp/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using T4MVCHostMvcApp.Misc;
@@ -101,6 +102,30 @@ namespace T4MVCHostMvcApp.Controllers
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param"), SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed"), SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Params"), SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "n"), SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
         public virtual ActionResult ActionWithOptionalParamDefaultingToNull(int? n = null)
+        {
+            return new EmptyResult();
+        }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param"), SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed"), SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Params"), SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public virtual ActionResult ActionWithOptionalParamDefaultingToDefaultValue(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return new EmptyResult();
+        }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param"), SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed"), SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Params"), SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public virtual ActionResult ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            return new EmptyResult();
+        }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param"), SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed"), SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Params"), SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public virtual ActionResult ActionWithOptionalParamDefaultingToDefaultValueWithSpaces(CancellationToken cancellationToken = default ( CancellationToken ) )
+        {
+            return new EmptyResult();
+        }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param"), SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed"), SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Params"), SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public virtual ActionResult ActionWithOptionalParamDefaultingToConstructedDefaultValue(CancellationToken cancellationToken = new CancellationToken())
         {
             return new EmptyResult();
         }

--- a/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
@@ -132,6 +132,10 @@ namespace T4MVCHostMvcApp.Controllers
             public readonly string ActionWithAllOptionalParams = "ActionWithAllOptionalParams";
             public readonly string ActionWithSomeOptionalParams = "ActionWithSomeOptionalParams";
             public readonly string ActionWithOptionalParamDefaultingToNull = "ActionWithOptionalParamDefaultingToNull";
+            public readonly string ActionWithOptionalParamDefaultingToDefaultValue = "ActionWithOptionalParamDefaultingToDefaultValue";
+            public readonly string ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName = "ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName";
+            public readonly string ActionWithOptionalParamDefaultingToDefaultValueWithSpaces = "ActionWithOptionalParamDefaultingToDefaultValueWithSpaces";
+            public readonly string ActionWithOptionalParamDefaultingToConstructedDefaultValue = "ActionWithOptionalParamDefaultingToConstructedDefaultValue";
             public readonly string ActionWithParamUsingAtSyntax = "ActionWithParamUsingAtSyntax";
             public readonly string ActionThatUsesActionNameConstantInAttribute = "ActionThatUsesActionNameConstantInAttribute";
             public readonly string ActionThatRequiresHttps = "ActionThatRequiresHttps";
@@ -161,6 +165,10 @@ namespace T4MVCHostMvcApp.Controllers
             public const string ActionWithAllOptionalParams = "ActionWithAllOptionalParams";
             public const string ActionWithSomeOptionalParams = "ActionWithSomeOptionalParams";
             public const string ActionWithOptionalParamDefaultingToNull = "ActionWithOptionalParamDefaultingToNull";
+            public const string ActionWithOptionalParamDefaultingToDefaultValue = "ActionWithOptionalParamDefaultingToDefaultValue";
+            public const string ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName = "ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName";
+            public const string ActionWithOptionalParamDefaultingToDefaultValueWithSpaces = "ActionWithOptionalParamDefaultingToDefaultValueWithSpaces";
+            public const string ActionWithOptionalParamDefaultingToConstructedDefaultValue = "ActionWithOptionalParamDefaultingToConstructedDefaultValue";
             public const string ActionWithParamUsingAtSyntax = "ActionWithParamUsingAtSyntax";
             public const string ActionThatUsesActionNameConstantInAttribute = "ActionThatUsesActionNameConstantInAttribute";
             public const string ActionThatRequiresHttps = "ActionThatRequiresHttps";
@@ -216,6 +224,38 @@ namespace T4MVCHostMvcApp.Controllers
         public class ActionParamsClass_ActionWithOptionalParamDefaultingToNull
         {
             public readonly string n = "n";
+        }
+        static readonly ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValue s_params_ActionWithOptionalParamDefaultingToDefaultValue = new ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValue();
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValue ActionWithOptionalParamDefaultingToDefaultValueParams { get { return s_params_ActionWithOptionalParamDefaultingToDefaultValue; } }
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public class ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValue
+        {
+            public readonly string cancellationToken = "cancellationToken";
+        }
+        static readonly ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName s_params_ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName = new ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName();
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeNameParams { get { return s_params_ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName; } }
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public class ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName
+        {
+            public readonly string cancellationToken = "cancellationToken";
+        }
+        static readonly ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithSpaces s_params_ActionWithOptionalParamDefaultingToDefaultValueWithSpaces = new ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithSpaces();
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithSpaces ActionWithOptionalParamDefaultingToDefaultValueWithSpacesParams { get { return s_params_ActionWithOptionalParamDefaultingToDefaultValueWithSpaces; } }
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public class ActionParamsClass_ActionWithOptionalParamDefaultingToDefaultValueWithSpaces
+        {
+            public readonly string cancellationToken = "cancellationToken";
+        }
+        static readonly ActionParamsClass_ActionWithOptionalParamDefaultingToConstructedDefaultValue s_params_ActionWithOptionalParamDefaultingToConstructedDefaultValue = new ActionParamsClass_ActionWithOptionalParamDefaultingToConstructedDefaultValue();
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public ActionParamsClass_ActionWithOptionalParamDefaultingToConstructedDefaultValue ActionWithOptionalParamDefaultingToConstructedDefaultValueParams { get { return s_params_ActionWithOptionalParamDefaultingToConstructedDefaultValue; } }
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public class ActionParamsClass_ActionWithOptionalParamDefaultingToConstructedDefaultValue
+        {
+            public readonly string cancellationToken = "cancellationToken";
         }
         static readonly ActionParamsClass_ActionWithParamUsingAtSyntax s_params_ActionWithParamUsingAtSyntax = new ActionParamsClass_ActionWithParamUsingAtSyntax();
         [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
@@ -531,6 +571,58 @@ namespace T4MVCHostMvcApp.Controllers
         }
 
         [NonAction]
+        partial void ActionWithOptionalParamDefaultingToDefaultValueOverride(T4MVC_System_Web_Mvc_ActionResult callInfo, System.Threading.CancellationToken cancellationToken);
+
+        [NonAction]
+        public override System.Web.Mvc.ActionResult ActionWithOptionalParamDefaultingToDefaultValue(System.Threading.CancellationToken cancellationToken)
+        {
+            var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.ActionWithOptionalParamDefaultingToDefaultValue);
+            if (cancellationToken != default(System.Threading.CancellationToken))
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "cancellationToken", cancellationToken);
+            ActionWithOptionalParamDefaultingToDefaultValueOverride(callInfo, cancellationToken);
+            return callInfo;
+        }
+
+        [NonAction]
+        partial void ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeNameOverride(T4MVC_System_Web_Mvc_ActionResult callInfo, System.Threading.CancellationToken cancellationToken);
+
+        [NonAction]
+        public override System.Web.Mvc.ActionResult ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName(System.Threading.CancellationToken cancellationToken)
+        {
+            var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeName);
+            if (cancellationToken != default(System.Threading.CancellationToken))
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "cancellationToken", cancellationToken);
+            ActionWithOptionalParamDefaultingToDefaultValueWithFullyQualifiedTypeNameOverride(callInfo, cancellationToken);
+            return callInfo;
+        }
+
+        [NonAction]
+        partial void ActionWithOptionalParamDefaultingToDefaultValueWithSpacesOverride(T4MVC_System_Web_Mvc_ActionResult callInfo, System.Threading.CancellationToken cancellationToken);
+
+        [NonAction]
+        public override System.Web.Mvc.ActionResult ActionWithOptionalParamDefaultingToDefaultValueWithSpaces(System.Threading.CancellationToken cancellationToken)
+        {
+            var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.ActionWithOptionalParamDefaultingToDefaultValueWithSpaces);
+            if (cancellationToken != default(System.Threading.CancellationToken))
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "cancellationToken", cancellationToken);
+            ActionWithOptionalParamDefaultingToDefaultValueWithSpacesOverride(callInfo, cancellationToken);
+            return callInfo;
+        }
+
+        [NonAction]
+        partial void ActionWithOptionalParamDefaultingToConstructedDefaultValueOverride(T4MVC_System_Web_Mvc_ActionResult callInfo, System.Threading.CancellationToken cancellationToken);
+
+        [NonAction]
+        public override System.Web.Mvc.ActionResult ActionWithOptionalParamDefaultingToConstructedDefaultValue(System.Threading.CancellationToken cancellationToken)
+        {
+            var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.ActionWithOptionalParamDefaultingToConstructedDefaultValue);
+            if (cancellationToken != new System.Threading.CancellationToken())
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "cancellationToken", cancellationToken);
+            ActionWithOptionalParamDefaultingToConstructedDefaultValueOverride(callInfo, cancellationToken);
+            return callInfo;
+        }
+
+        [NonAction]
         partial void ActionWithParamUsingAtSyntaxOverride(T4MVC_System_Web_Mvc_ActionResult callInfo, int @event);
 
         [NonAction]
@@ -615,7 +707,7 @@ namespace T4MVCHostMvcApp.Controllers
         partial void ActionReturningGenericResultNestedOverride(T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32 callInfo);
 
         [NonAction]
-        public override T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String,System.String,System.Int32>>> ActionReturningGenericResultNested()
+        public override T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String, System.String, System.Int32>>> ActionReturningGenericResultNested()
         {
             var callInfo = new T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32(Area, Name, ActionNames.ActionReturningGenericResultNested);
             ActionReturningGenericResultNestedOverride(callInfo);

--- a/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
@@ -495,8 +495,10 @@ namespace T4MVCHostMvcApp.Controllers
         public override System.Web.Mvc.ActionResult ActionWithAllOptionalParams(string someString, int n)
         {
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.ActionWithAllOptionalParams);
-            ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "someString", someString);
-            ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "n", n);
+            if (someString != "Hello")
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "someString", someString);
+            if (n != 5)
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "n", n);
             ActionWithAllOptionalParamsOverride(callInfo, someString, n);
             return callInfo;
         }
@@ -509,7 +511,8 @@ namespace T4MVCHostMvcApp.Controllers
         {
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.ActionWithSomeOptionalParams);
             ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "someString", someString);
-            ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "n", n);
+            if (n != 5)
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "n", n);
             ActionWithSomeOptionalParamsOverride(callInfo, someString, n);
             return callInfo;
         }
@@ -521,7 +524,8 @@ namespace T4MVCHostMvcApp.Controllers
         public override System.Web.Mvc.ActionResult ActionWithOptionalParamDefaultingToNull(int? n)
         {
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.ActionWithOptionalParamDefaultingToNull);
-            ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "n", n);
+            if (n != null)
+                ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "n", n);
             ActionWithOptionalParamDefaultingToNullOverride(callInfo, n);
             return callInfo;
         }

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
@@ -207,7 +207,7 @@ internal partial class T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_Syste
     public RouteValueDictionary RouteValueDictionary { get; set; }
 }
 [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
-internal partial class T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32 : T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String,System.String,System.Int32>>>, IT4MVCActionResult
+internal partial class T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32 : T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String, System.String, System.Int32>>>, IT4MVCActionResult
 {
     public T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32(string area, string controller, string action, string protocol = null): base(" ")
     {

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.nuspec
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>T4MVC</id>
-    <version>3.15.4</version>
+    <version>3.15.5</version>
     <authors>David Ebbo</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>T4MVC is a T4 template that generates strongly typed helpers for ASP.NET MVC.</description>
@@ -12,7 +12,7 @@
     <projectUrl>https://github.com/T4MVC/T4MVC</projectUrl>
     <tags>t4 mvc t4mvc</tags>
     <dependencies>
-      <dependency id="T4MVCExtensions" version="3.15.4" />
+      <dependency id="T4MVCExtensions" version="3.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1,6 +1,6 @@
 ﻿<#
 /*
-T4MVC Version 3.15.4
+T4MVC Version 3.15.5
 Find latest version and documentation at https://github.com/T4MVC/T4MVC/wiki/Documentation
 Discuss on StackOverflow or on GitHub (https://github.com/T4MVC/T4MVC/issues)
 
@@ -370,6 +370,9 @@ foreach (var group in controller.UniqueParameterNamesGroupedByActionName) if (gr
             var callInfo = new T4MVC_<#=method.ReturnTypeUniqueName #>(Area, Name, ActionNames.<#=method.ActionName #><# if (method.ActionUrlHttps) {#>, "https"<#}#>);
 <#if (method.Parameters.Count > 0) { #>
 <#foreach (var p in method.Parameters) { #>
+<# if (p.DefaultValue != null) { #>
+            if (<#=p.Name #> != <#=p.DefaultValue#>)
+    <# } #>
             ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, <#=p.RouteNameExpression #>, <#=p.Name #>);
 <#} #>
 <#}#>

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -33,8 +33,8 @@ Please use in accordance to the Apache license (http://mvccontrib.codeplex.com/l
 <#@ import namespace="EnvDTE80" #>
 <#@ import namespace="Microsoft.VisualStudio.TextTemplating" #>
 <# // To debug, uncomment the next two lines !! 
-// System.Diagnostics.Debugger.Launch();
-// System.Diagnostics.Debugger.Break();
+//System.Diagnostics.Debugger.Launch();
+//System.Diagnostics.Debugger.Break();
 #>
 <#settings=MvcSettings.Load(Host);#>
 <#PrepareDataToRender(this); #>
@@ -371,7 +371,7 @@ foreach (var group in controller.UniqueParameterNamesGroupedByActionName) if (gr
 <#if (method.Parameters.Count > 0) { #>
 <#foreach (var p in method.Parameters) { #>
 <# if (p.DefaultValue != null) { #>
-            if (<#=p.Name #> != <#=p.DefaultValue#>)
+            if (<#=p.Name #> != <#=SanitizeDefaultValue(p.DefaultValue, p.Type)#>)
     <# } #>
             ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, <#=p.RouteNameExpression #>, <#=p.Name #>);
 <#} #>
@@ -1651,6 +1651,23 @@ static string Sanitize(string token)
 static string EscapeID(string id)
 {
     return codeProvider.CreateEscapedIdentifier(id);
+}
+
+static string SanitizeDefaultValue(string defaultValue, string type)
+{
+	// Normalize default values that are
+	// 1. default(T) for some type T
+	// 2. The parameterless constructor of a value type
+	if (Regex.IsMatch(defaultValue, @"^\s*default\s*\(.*?\)"))
+    {
+		defaultValue = string.Format("default({0})", type);
+    }
+	else if(Regex.IsMatch(defaultValue, @"^\s*new\s*.*?\s*\(\s*\)"))
+    {
+		defaultValue = string.Format("new {0}()", type);
+    }
+
+	return defaultValue;
 }
 
 // Data structure to collect data about an area

--- a/T4MVCHostMvcApp/T4MVC Files/readme.txt
+++ b/T4MVCHostMvcApp/T4MVC Files/readme.txt
@@ -49,6 +49,9 @@ KNOWN ISSUES:
 
 HISTORY:
 
+!!! 3.15.5 (8-28-2015)
+* Don't add default params to routes. [url:https://github.com/T4MVC/T4MVC/issues/44]
+
 !!! 3.15.4 (5-27-2015)
 * Updated pragmas to avoid unnecessary warnings. [url:https://github.com/T4MVC/T4MVC/pull/33]
 


### PR DESCRIPTION
PR for https://github.com/T4MVC/T4MVC/issues/44

Introduction of a `SanitizeDefaultValue(string defaultValue, string type)` method that takes the default value string and type of an action method parameter and attempts a regex match for
1. `default(T)` for some type T
2. parameterless constructor for a type (valid optional parameter for a Value type)

if a match is found, the match is replaced with a corresponding string that uses the fully qualified type name, and this value is compared against the value for an action parameter to determine if the value should be added to the `RouteValueDictionary` and used in rendering a url for the controller action.

For example,

`default(CancellationToken)` is replaced with `default(System.Threading.CancellationToken)`
`default(    CancellationToken   )` is replaced with `default(System.Threading.CancellationToken)`
`new CancellationToken()` is replaced with `new System.Threading.CancellationToken()`

with a controller action such as

```
public partial class HomeController : Controller
{
    public virtual async Task<ActionResult> Index(CancellationToken cancellationToken = default(CancellationToken))
    {
        // perform some work that uses the cancellation token
        await Task.Delay(1000, cancellationToken);

        return View();
    }
}
```

when a T4MVC overload such as `Url.Action(MVC.Home.Index())` is used to generate a url for the controller action, a query string parameter is not appended to the generated url for the default value of the cancellation token passed as an optional parameter.
