### PR TITLE
Fix missing cache-busters from other assets

### DIFF
--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1313,10 +1313,16 @@ if (!settings.ExcludedStaticFileExtensions.Any(extension => projectItem.Name.End
     public static readonly string <#=name#> = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(URLPATH + "/<#=minifiedName#>") ? Url("<#=minifiedName#>") : Url("<#=nonMinifiedName#>");
 <#+}  #>
 <#+}
+else if (AddTimestampToStaticLink(projectItem)) { #>
+    public static readonly string <#=name#> = Url("<#=projectItem.Name#>")+"?"+T4MVCHelpers.TimestampString(URLPATH + "/<#=projectItem.Name#>");
+<#+}
     else { #>
     public static readonly string <#=name#> = Url("<#=projectItem.Name#>");
 <#+}
-	}
+    }
+    else if (AddTimestampToStaticLink(projectItem)) { #>
+    public static readonly string <#=name#> = Url("<#=projectItem.Name#>")+"?"+T4MVCHelpers.TimestampString(URLPATH + "/<#=projectItem.Name#>");
+<#+}
     else { #>
     public static readonly string <#=name#> = Url("<#=projectItem.Name#>");
 <#+}


### PR DESCRIPTION
Latest build for us removed cache-busting from png files and other "unmapped" assets. This PR hopefully puts them back in.

Would this functionality be better suited in the Url method itself moving forwards?
