### PR TITLE
Fix `ArgumentOutOfRange: StartIndex cannot be less than zero`

### DIFF
--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1298,7 +1298,7 @@ PopIndent();
 
 if (!settings.ExcludedStaticFileExtensions.Any(extension => projectItem.Name.EndsWith(extension, StringComparison.OrdinalIgnoreCase))) {
 
-    var extension = projectItem.Name.Substring(projectItem.Name.LastIndexOf("."));
+    var extension = Path.GetExtension(projectItem.Name);
 
     if(mapping.ContainsKey(extension))
     {


### PR DESCRIPTION
... for files without extensions such as `LICENSE`
