### PR TITLE
Overloads for task based, derived action results

### DIFF
--- a/T4MVCExtensions/GenericT4Extensions.cs
+++ b/T4MVCExtensions/GenericT4Extensions.cs
@@ -1,0 +1,242 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Web.Mvc.Ajax;
+using System.Web.Mvc.Html;
+using System.Web.Routing;
+
+namespace System.Web.Mvc {
+    public static class GenericT4Extensions {
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(htmlHelper, linkText, taskResult.Result, (IDictionary<string, object>)null, (string)null, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(htmlHelper, linkText, taskResult.Result, htmlAttributes, (string)null, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, object htmlAttributes, string protocol) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(htmlHelper, linkText, taskResult.Result, htmlAttributes, protocol, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, object htmlAttributes, string protocol, string hostName) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(htmlHelper, linkText, taskResult.Result, htmlAttributes, protocol, hostName, (string)null);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, object htmlAttributes, string protocol, string hostName, string fragment) where TActionResult : ActionResult {
+            return LinkExtensions.RouteLink(htmlHelper, linkText, (string)null, protocol ?? T4Extensions.GetT4MVCResult(taskResult.Result).Protocol, hostName, fragment, T4Extensions.GetRouteValueDictionary(taskResult.Result), (IDictionary<string, object>)HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(htmlHelper, linkText, taskResult.Result, htmlAttributes, (string)null, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes, string protocol) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(htmlHelper, linkText, taskResult.Result, htmlAttributes, protocol, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes, string protocol, string hostName) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(htmlHelper, linkText, taskResult.Result, htmlAttributes, protocol, hostName, (string)null);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes, string protocol, string hostName, string fragment) where TActionResult : ActionResult {
+            return LinkExtensions.RouteLink(htmlHelper, linkText, (string)null, protocol ?? T4Extensions.GetT4MVCResult(taskResult.Result).Protocol, hostName, fragment, T4Extensions.GetRouteValueDictionary(taskResult.Result), htmlAttributes);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, (string)null, taskResult.Result, htmlAttributes, (string)null, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, htmlAttributes, (string)null, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, object htmlAttributes, string protocol) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, htmlAttributes, protocol, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, object htmlAttributes, string protocol, string hostName) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, htmlAttributes, protocol, hostName, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, object htmlAttributes, string protocol, string hostName, string fragment) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, (IDictionary<string, object>)HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes), protocol, hostName, fragment);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, (string)null, taskResult.Result, htmlAttributes, (string)null, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, htmlAttributes, (string)null, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes, string protocol) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, htmlAttributes, protocol, (string)null, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes, string protocol, string hostName) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, htmlAttributes, protocol, hostName, (string)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this HtmlHelper htmlHelper, string linkText, string routeName, Task<TActionResult> taskResult, IDictionary<string, object> htmlAttributes, string protocol, string hostName, string fragment) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(htmlHelper, linkText, routeName, taskResult.Result, htmlAttributes, protocol, hostName, fragment);
+        }
+
+        public static MvcForm BeginForm<TActionResult>(this HtmlHelper htmlHelper, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.BeginForm(htmlHelper, taskResult.Result, FormMethod.Post);
+        }
+
+        public static MvcForm BeginForm<TActionResult>(this HtmlHelper htmlHelper, Task<TActionResult> taskResult, FormMethod formMethod) where TActionResult : ActionResult {
+            return T4Extensions.BeginForm(htmlHelper, taskResult.Result, formMethod, (IDictionary<string, object>)null);
+        }
+
+        public static MvcForm BeginForm<TActionResult>(this HtmlHelper htmlHelper, Task<TActionResult> taskResult, FormMethod formMethod, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.BeginForm(htmlHelper, taskResult.Result, formMethod, (IDictionary<string, object>)HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static MvcForm BeginForm<TActionResult>(this HtmlHelper htmlHelper, Task<TActionResult> taskResult, FormMethod formMethod, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.BeginForm(htmlHelper, taskResult.Result, formMethod, htmlAttributes);
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this HtmlHelper htmlHelper, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(htmlHelper, (string)null, taskResult.Result, FormMethod.Post, (IDictionary<string, object>)null);
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this HtmlHelper htmlHelper, string routeName, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(htmlHelper, routeName, taskResult.Result, FormMethod.Post, (IDictionary<string, object>)null);
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this HtmlHelper htmlHelper, string routeName, Task<TActionResult> taskResult, FormMethod method) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(htmlHelper, routeName, taskResult.Result, method, (IDictionary<string, object>)null);
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this HtmlHelper htmlHelper, string routeName, Task<TActionResult> taskResult, FormMethod method, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(htmlHelper, routeName, taskResult.Result, method, (IDictionary<string, object>)HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this HtmlHelper htmlHelper, string routeName, Task<TActionResult> taskResult, FormMethod method, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(htmlHelper, routeName, taskResult.Result, method, htmlAttributes);
+        }
+
+        public static void RenderAction<TActionResult>(this HtmlHelper htmlHelper, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            T4Extensions.RenderAction(htmlHelper, taskResult.Result);
+        }
+
+        public static MvcHtmlString Action<TActionResult>(this HtmlHelper htmlHelper, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.Action(htmlHelper, taskResult.Result);
+        }
+
+        public static string Action<TActionResult>(this UrlHelper urlHelper, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.Action(urlHelper, taskResult.Result, (string)null, (string)null);
+        }
+
+        public static string Action<TActionResult>(this UrlHelper urlHelper, Task<TActionResult> taskResult, string protocol = null, string hostName = null) where TActionResult : ActionResult {
+            return T4Extensions.Action(urlHelper, taskResult.Result, protocol, hostName);
+        }
+
+        public static string ActionAbsolute<TActionResult>(this UrlHelper urlHelper, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.ActionAbsolute(urlHelper, taskResult.Result);
+        }
+
+        public static string RouteUrl<TActionResult>(this UrlHelper urlHelper, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.RouteUrl(urlHelper, (string)null, taskResult.Result, (string)null, (string)null);
+        }
+
+        public static string RouteUrl<TActionResult>(this UrlHelper urlHelper, string routeName, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.RouteUrl(urlHelper, routeName, taskResult.Result, (string)null, (string)null);
+        }
+
+        public static string RouteUrl<TActionResult>(this UrlHelper urlHelper, string routeName, Task<TActionResult> taskResult, string protocol) where TActionResult : ActionResult {
+            return T4Extensions.RouteUrl(urlHelper, routeName, taskResult.Result, protocol, (string)null);
+        }
+
+        public static string RouteUrl<TActionResult>(this UrlHelper urlHelper, string routeName, Task<TActionResult> taskResult, string protocol, string hostName) where TActionResult : ActionResult {
+            return T4Extensions.RouteUrl(urlHelper, routeName, taskResult.Result, protocol, hostName);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this AjaxHelper ajaxHelper, string linkText, Task<TActionResult> taskResult, AjaxOptions ajaxOptions) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(ajaxHelper, linkText, taskResult.Result, ajaxOptions);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this AjaxHelper ajaxHelper, string linkText, Task<TActionResult> taskResult, AjaxOptions ajaxOptions, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(ajaxHelper, linkText, taskResult.Result, ajaxOptions, htmlAttributes);
+        }
+
+        public static MvcHtmlString ActionLink<TActionResult>(this AjaxHelper ajaxHelper, string linkText, Task<TActionResult> taskResult, AjaxOptions ajaxOptions, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.ActionLink(ajaxHelper, linkText, taskResult.Result, ajaxOptions, htmlAttributes);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this AjaxHelper ajaxHelper, string linkText, string routeName, Task<TActionResult> taskResult, AjaxOptions ajaxOptions) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(ajaxHelper, linkText, routeName, taskResult.Result, ajaxOptions, (IDictionary<string, object>)null);
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this AjaxHelper ajaxHelper, string linkText, string routeName, Task<TActionResult> taskResult, AjaxOptions ajaxOptions, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(ajaxHelper, linkText, routeName, taskResult.Result, ajaxOptions, (IDictionary<string, object>)HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static MvcHtmlString RouteLink<TActionResult>(this AjaxHelper ajaxHelper, string linkText, string routeName, Task<TActionResult> taskResult, AjaxOptions ajaxOptions, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.RouteLink(ajaxHelper, linkText, routeName, taskResult.Result, ajaxOptions, htmlAttributes);
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this AjaxHelper ajaxHelper, string routeName, Task<TActionResult> taskResult, AjaxOptions ajaxOptions) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(ajaxHelper, routeName, taskResult.Result, ajaxOptions, (IDictionary<string, object>)null);
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this AjaxHelper ajaxHelper, string routeName, Task<TActionResult> taskResult, AjaxOptions ajaxOptions, object htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(ajaxHelper, routeName, taskResult.Result, ajaxOptions, (IDictionary<string, object>)HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static MvcForm BeginRouteForm<TActionResult>(this AjaxHelper ajaxHelper, string routeName, Task<TActionResult> taskResult, AjaxOptions ajaxOptions, IDictionary<string, object> htmlAttributes) where TActionResult : ActionResult {
+            return T4Extensions.BeginRouteForm(ajaxHelper, routeName, taskResult.Result, ajaxOptions, htmlAttributes);
+        }
+
+        public static Route MapRoute<TActionResult>(this RouteCollection routes, string name, string url, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.MapRoute(routes, name, url, taskResult.Result, (string[])null);
+        }
+
+        public static Route MapRoute<TActionResult>(this RouteCollection routes, string name, string url, Task<TActionResult> taskResult, object defaults) where TActionResult : ActionResult {
+            return T4Extensions.MapRoute(routes, name, url, taskResult.Result, defaults, (object)null, (string[])null);
+        }
+
+        public static Route MapRoute<TActionResult>(this RouteCollection routes, string name, string url, Task<TActionResult> taskResult, string[] namespaces) where TActionResult : ActionResult {
+            return T4Extensions.MapRoute(routes, name, url, taskResult.Result, (object)null, namespaces);
+        }
+
+        public static Route MapRoute<TActionResult>(this RouteCollection routes, string name, string url, Task<TActionResult> taskResult, object defaults, object constraints) where TActionResult : ActionResult {
+            return T4Extensions.MapRoute(routes, name, url, taskResult.Result, defaults, constraints, (string[])null);
+        }
+
+        public static Route MapRoute<TActionResult>(this RouteCollection routes, string name, string url, Task<TActionResult> taskResult, object defaults, string[] namespaces) where TActionResult : ActionResult {
+            return T4Extensions.MapRoute(routes, name, url, taskResult.Result, defaults, (object)null, namespaces);
+        }
+
+        public static Route MapRoute<TActionResult>(this RouteCollection routes, string name, string url, Task<TActionResult> taskResult, object defaults, object constraints, string[] namespaces) where TActionResult : ActionResult {
+            return T4Extensions.MapRoute(routes, name, url, taskResult.Result, defaults, constraints, namespaces);
+        }
+
+        public static Route MapRouteArea<TActionResult>(this AreaRegistrationContext context, string name, string url, Task<TActionResult> taskResult) where TActionResult : ActionResult {
+            return T4Extensions.MapRouteArea(context, name, url, taskResult.Result, (string[])null);
+        }
+
+        public static Route MapRouteArea<TActionResult>(this AreaRegistrationContext context, string name, string url, Task<TActionResult> taskResult, object defaults) where TActionResult : ActionResult {
+            return T4Extensions.MapRouteArea(context, name, url, taskResult.Result, defaults, (object)null, (string[])null);
+        }
+
+        public static Route MapRouteArea<TActionResult>(this AreaRegistrationContext context, string name, string url, Task<TActionResult> taskResult, string[] namespaces) where TActionResult : ActionResult {
+            return T4Extensions.MapRouteArea(context, name, url, taskResult.Result, (object)null, namespaces);
+        }
+
+        public static Route MapRouteArea<TActionResult>(this AreaRegistrationContext context, string name, string url, Task<TActionResult> taskResult, object defaults, object constraints) where TActionResult : ActionResult {
+            return T4Extensions.MapRouteArea(context, name, url, taskResult.Result, defaults, constraints, (string[])null);
+        }
+
+        public static Route MapRouteArea<TActionResult>(this AreaRegistrationContext context, string name, string url, Task<TActionResult> taskResult, object defaults, string[] namespaces) where TActionResult : ActionResult {
+            return T4Extensions.MapRouteArea(context, name, url, taskResult.Result, defaults, (object)null, namespaces);
+        }
+
+        public static Route MapRouteArea<TActionResult>(this AreaRegistrationContext context, string name, string url, Task<TActionResult> taskResult, object defaults, object constraints, string[] namespaces) where TActionResult : ActionResult {
+            return T4Extensions.MapRouteArea(context, name, url, taskResult.Result, defaults, constraints, namespaces);
+        }
+    }
+
+}

--- a/T4MVCExtensions/T4MVCExtensions.csproj
+++ b/T4MVCExtensions/T4MVCExtensions.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DefaultModelUnbinder.cs" />
+    <Compile Include="GenericT4Extensions.cs" />
     <Compile Include="IModelUnbinder.cs" />
     <Compile Include="IModelUnbinderProvider.cs" />
     <Compile Include="IT4MVCActionResult.cs" />

--- a/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/HomeController.generated.cs
@@ -100,7 +100,7 @@ namespace T4MVCHostMvcApp.Controllers
         public virtual System.Threading.Tasks.Task<System.Web.Mvc.ActionResult> SomeTaskBasedActionWithParams()
         {
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.SomeTaskBasedActionWithParams);
-            return System.Threading.Tasks.Task.FromResult(callInfo as ActionResult);
+            return System.Threading.Tasks.Task.FromResult(callInfo as System.Web.Mvc.ActionResult);
         }
 
         [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
@@ -432,7 +432,7 @@ namespace T4MVCHostMvcApp.Controllers
         {
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.AsyncTask);
             AsyncTaskOverride(callInfo);
-            return System.Threading.Tasks.Task.FromResult(callInfo as ActionResult);
+            return System.Threading.Tasks.Task.FromResult(callInfo as System.Web.Mvc.ActionResult);
         }
 
         [NonAction]
@@ -719,7 +719,7 @@ namespace T4MVCHostMvcApp.Controllers
         partial void ActionReturningGenericResultNestedOverride(T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32 callInfo);
 
         [NonAction]
-        public override T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String, System.String, System.Int32>>> ActionReturningGenericResultNested()
+        public override T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String,System.String,System.Int32>>> ActionReturningGenericResultNested()
         {
             var callInfo = new T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32(Area, Name, ActionNames.ActionReturningGenericResultNested);
             ActionReturningGenericResultNestedOverride(callInfo);
@@ -734,7 +734,7 @@ namespace T4MVCHostMvcApp.Controllers
         {
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.SomeTaskBasedAction);
             SomeTaskBasedActionOverride(callInfo);
-            return System.Threading.Tasks.Task.FromResult(callInfo as ActionResult);
+            return System.Threading.Tasks.Task.FromResult(callInfo as System.Web.Mvc.ActionResult);
         }
 
         [NonAction]
@@ -746,7 +746,7 @@ namespace T4MVCHostMvcApp.Controllers
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.SomeTaskBasedActionWithParams);
             ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "id", id);
             SomeTaskBasedActionWithParamsOverride(callInfo, id);
-            return System.Threading.Tasks.Task.FromResult(callInfo as ActionResult);
+            return System.Threading.Tasks.Task.FromResult(callInfo as System.Web.Mvc.ActionResult);
         }
 
         [NonAction]

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
@@ -207,7 +207,7 @@ internal partial class T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_Syste
     public RouteValueDictionary RouteValueDictionary { get; set; }
 }
 [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
-internal partial class T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32 : T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String, System.String, System.Int32>>>, IT4MVCActionResult
+internal partial class T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32 : T4MVCHostMvcApp.Controllers.SomeGenericResult<System.Collections.Generic.List<System.Tuple<System.String,System.String,System.Int32>>>, IT4MVCActionResult
 {
     public T4MVC_T4MVCHostMvcApp_Controllers_SomeGenericResult_System_Collections_Generic_List_System_Tuple_System_String_System_String_System_Int32(string area, string controller, string action, string protocol = null): base(" ")
     {

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -12,7 +12,7 @@ http://blog.davidebbo.com/ (previously: http://blogs.msdn.com/davidebb)
 
 Related blog posts: http://blogs.msdn.com/davidebb/archive/tags/T4MVC/default.aspx
 
-Please use in accordance to the license (https://github.com/T4MVC/T4MVC/blob/master/License.txt)
+Please use in accordance to the license (https://github.com/T4MVC/T4MVC/blob/master/License.txt) 
 */
 #>
 <#@ template language="C#" debug="true" hostspecific="true" #>
@@ -236,9 +236,9 @@ namespace <#=controller.Namespace #>
         [<#= GeneratedCode #>, DebuggerNonUserCode]
         public virtual <#=method.ReturnTypeFullName #> <#=method.Name #>()
         {
-<#if (method.ReturnTypeFullName == "System.Threading.Tasks.Task<System.Web.Mvc.ActionResult>") { #>
+<#if (method.IsTaskBased) { #>
             var callInfo = new T4MVC_<#=method.ReturnTypeUniqueName #>(Area, Name, ActionNames.<#=method.ActionName #><# if (method.ActionUrlHttps) {#>, "https"<#}#>);
-            return System.Threading.Tasks.Task.FromResult(callInfo as ActionResult);
+            return System.Threading.Tasks.Task.FromResult(callInfo as <#=method.TaskActionTypeFullName #>);
 <#} else { #>
             return new T4MVC_<#=method.ReturnTypeUniqueName #>(Area, Name, ActionNames.<#=method.ActionName #><# if (method.ActionUrlHttps) {#>, "https"<#}#>);
 <#} #>
@@ -263,8 +263,8 @@ namespace <#=controller.Namespace #>
             ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, <#=p.RouteNameExpression #>, <#=p.Name #>);
 <#} #>
 <#}#>
-<#if (method.ReturnTypeFullName == "System.Threading.Tasks.Task<System.Web.Mvc.ActionResult>") { #>
-            return System.Threading.Tasks.Task.FromResult(callInfo as ActionResult);
+<#if (method.IsTaskBased) { #>
+            return System.Threading.Tasks.Task.FromResult(callInfo as <#=method.TaskActionTypeFullName #>);
 <#} else { #>
             return callInfo;
 <#} #>
@@ -374,8 +374,8 @@ foreach (var group in controller.UniqueParameterNamesGroupedByActionName) if (gr
 <#} #>
 <#}#>
             <#=method.Name #>Override(callInfo<#if (method.Parameters.Count > 0) { #><#foreach (var p in method.Parameters) { #>, <#=p.Name #><#}}#>);
-<#if (method.ReturnTypeFullName == "System.Threading.Tasks.Task<System.Web.Mvc.ActionResult>") { #>
-            return System.Threading.Tasks.Task.FromResult(callInfo as ActionResult);
+<#if (method.IsTaskBased) { #>
+            return System.Threading.Tasks.Task.FromResult(callInfo as <#=method.TaskActionTypeFullName #>);
 <#} else { #>
             return callInfo;
 <#} #>
@@ -449,6 +449,39 @@ static string T4Folder;
 static string GeneratedCode = @"GeneratedCode(""T4MVC"", ""2.0"")";
 static Microsoft.CSharp.CSharpCodeProvider codeProvider = new Microsoft.CSharp.CSharpCodeProvider();
 List<string> virtualPathesForStaticFiles = new List<string>();
+
+static CodeTypeRef TryCreateActionResultDerivedCodeTypeRef(CodeType codeType) {
+	return codeType.get_IsDerivedFrom("System.Web.Mvc.ActionResult")
+		? Project.CodeModel.CreateCodeTypeRef(codeType.FullName)
+		: null;
+}
+
+enum ActionTypeMatch {
+	None = 0,
+	Direct = 1,
+	TaskBased = 2
+}
+
+static ActionTypeMatch TryGetActionType(CodeType codeType, out CodeTypeRef actionTypeRef) {	
+	// check for task based
+	Match match = Regex.Match(codeType.FullName, "^System.Threading.Tasks.Task<(.+)>$");
+    if (match == null || !match.Success) {
+		actionTypeRef = TryCreateActionResultDerivedCodeTypeRef(codeType);		
+		return actionTypeRef != null
+			? ActionTypeMatch.Direct
+			: ActionTypeMatch.None;
+    } else {
+		CodeTypeRef typeRef = Project.CodeModel.CreateCodeTypeRef(match.Groups[1].Value);
+		if (typeRef.CodeType.get_IsDerivedFrom("System.Web.Mvc.ActionResult"))
+			actionTypeRef = typeRef;
+		else
+			actionTypeRef = null;
+		return actionTypeRef != null
+			? ActionTypeMatch.TaskBased
+			: ActionTypeMatch.None;    
+    }
+}
+
 
 IEnumerable<ControllerInfo> GetControllers()
 {
@@ -871,7 +904,9 @@ void ProcessControllerActionMethods(ControllerInfo controllerInfo, CodeClass2 cu
                 continue;
 
             // We only support action methods that return an ActionResult and Task<ActionResult> derived types
-            if (!method.Type.CodeType.get_IsDerivedFrom("System.Web.Mvc.ActionResult") && method.Type.CodeType.FullName !="System.Threading.Tasks.Task<System.Web.Mvc.ActionResult>")
+			CodeTypeRef methodType;
+			ActionTypeMatch match = TryGetActionType(method.Type.CodeType, out methodType);
+            if (match == ActionTypeMatch.None)
             {
                 // Comment out warning, as it's more annoying than helpful
                 //Warning(String.Format("{0} doesn't support {1}.{2} because it doesn't return a supported {3} type", T4FileName, type.Name, method.Name, method.Type.CodeType.FullName));
@@ -882,10 +917,6 @@ void ProcessControllerActionMethods(ControllerInfo controllerInfo, CodeClass2 cu
             // See http://stackoverflow.com/questions/5419173/t4mvc-asynccontroller
             if (isAsyncController && method.Name.EndsWith("Completed", StringComparison.OrdinalIgnoreCase))
                 continue;
-
-            var methodType = method.Type;
-            if(method.Type.CodeType.FullName == "System.Threading.Tasks.Task<System.Web.Mvc.ActionResult>")
-                methodType = Project.CodeModel.CreateCodeTypeRef("System.Web.Mvc.ActionResult");
 
             // If we haven't yet seen this return type, keep track of it
             var resTypeInfo2 = new ResultTypeInfo(methodType);
@@ -911,7 +942,7 @@ void ProcessControllerActionMethods(ControllerInfo controllerInfo, CodeClass2 cu
             }
 
             // Collect misc info about the action method and add it to the collection
-            controllerInfo.ActionMethods.Add(new ActionMethodInfo(method, current));
+            controllerInfo.ActionMethods.Add(new ActionMethodInfo(method, current, null, match == ActionTypeMatch.TaskBased ?  methodType : null));
         }
     }
 }
@@ -1962,10 +1993,13 @@ class FunctionInfo
 {
     protected CodeFunction2 _method;
     private string _signature;
+	protected CodeTypeRef _taskActionType;
 
-    public FunctionInfo(CodeFunction2 method)
+    public FunctionInfo(CodeFunction2 method, CodeTypeRef taskActionType = null)
     {
-        Parameters = new List<MethodParamInfo>();
+        _taskActionType = taskActionType;
+		
+		Parameters = new List<MethodParamInfo>();
 
         // Can be null when an custom ActionResult has no ctor
         if (method == null)
@@ -2019,12 +2053,12 @@ class FunctionInfo
     public string Name { get { return _method.Name; } }
     public string ReturnType { get { return ReturnTypeImpl.AsString; } }
     public string ReturnTypeFullName { get { return ReturnTypeImpl.AsFullName; } }
-    public string ReturnTypeUniqueName { get { return IsTaskBased ? "System_Web_Mvc_ActionResult" : UniqueFullName(ReturnTypeImpl); } }
+    public string ReturnTypeUniqueName { get { return IsTaskBased ?  UniqueFullName(_taskActionType) : UniqueFullName(ReturnTypeImpl); } }
     public bool IsPublic { get { return _method.Access == vsCMAccess.vsCMAccessPublic; } }
     public List<MethodParamInfo> Parameters { get; private set; }
     public bool CanBeCalledWithoutParameters { get; private set; }
 
-    private bool IsTaskBased { get {return ReturnTypeImpl.AsFullName == "System.Threading.Tasks.Task<System.Web.Mvc.ActionResult>"; } }
+    public bool IsTaskBased { get {return _taskActionType != null; } }
 
     // Write out all the parameters as part of a method declaration
     public void WriteFormalParameters(bool first, bool includeDefaults = false)
@@ -2087,15 +2121,19 @@ class FunctionInfo
 // Data structure to collect data about an action method
 class ActionMethodInfo : FunctionInfo
 {
-    public ActionMethodInfo(CodeFunction2 method, CodeClass2 controller, CodeTypeRef asyncType = null)
-        : base(method)
+    public ActionMethodInfo(CodeFunction2 method, CodeClass2 controller, CodeTypeRef asyncType = null, CodeTypeRef taskActionType = null)
+        : base(method, taskActionType)
     {
-        if(asyncType != null) 
-        {
-            // Remove the Async from the end of the name to match the actual Action routing would use.
-            // This also separates the Action Calls from the implementation
-            _actionName = method.Name.Remove(method.Name.Length - 5);
-            _returnType = asyncType;
+		if (taskActionType != null) {
+			_taskActionType = taskActionType;
+        } else {
+			if(asyncType != null) 
+			{
+				// Remove the Async from the end of the name to match the actual Action routing would use.
+				// This also separates the Action Calls from the implementation
+				_actionName = method.Name.Remove(method.Name.Length - 5);
+				_returnType = asyncType;
+			}
         }
         // Normally, the action name is the method name. But if there is an [ActionName] on
         // the method, get the expression from that instead
@@ -2115,7 +2153,15 @@ class ActionMethodInfo : FunctionInfo
 
     string _actionName;
     CodeTypeRef _returnType;
-    protected override CodeTypeRef ReturnTypeImpl { get { return _returnType ?? base.ReturnTypeImpl; } }
+    protected override CodeTypeRef ReturnTypeImpl { 
+		get { 
+			if (IsTaskBased)
+				return Project.CodeModel.CreateCodeTypeRef("System.Threading.Tasks.Task<" + _taskActionType.AsFullName + ">");
+			return _returnType ?? base.ReturnTypeImpl; 
+		}
+	}
+
+	public string TaskActionTypeFullName { get { return IsTaskBased ? _taskActionType.AsFullName : null; } }
 
     public string ActionName { get { return _actionName ?? base.Name; } }
     public string ActionNameValueExpression { get; set; }
@@ -2154,7 +2200,12 @@ class ResultTypeInfo
         }
     }
 
-    private bool IsTaskBased { get {return _codeType.AsFullName == "System.Threading.Tasks.Task<System.Web.Mvc.ActionResult>"; } }
+    private bool IsTaskBased { 
+		get {
+			CodeTypeRef methodType;			
+			return TryGetActionType(_codeType.CodeType, out methodType) == ActionTypeMatch.TaskBased;
+		} 
+	}
 }
 
 class MethodParamInfo


### PR DESCRIPTION
Extended the T4 to correctly process `Task<FooActionResult>` actions.

Also added generic methods to T4Extensions to simplify use of newly generated actions.

Should fix issue #57 
