### PR TITLE
Add helper method to determine if a type was generated by T4MVC

### DIFF
--- a/T4MVCExtensions/T4MVCExtensions.csproj
+++ b/T4MVCExtensions/T4MVCExtensions.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="T4Extensions.cs" />
     <Compile Include="T4MVCAttribute.cs" />
+    <Compile Include="T4TypeHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/T4MVCExtensions/T4TypeHelper.cs
+++ b/T4MVCExtensions/T4TypeHelper.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace T4MVCExtensions
+{
+    public static class T4TypeHelper
+    {
+        public static bool IsT4MVC(this Type t)
+        {
+            if (t.FullName.StartsWith("T4MVC"))
+                return true;
+
+            var attribute = t.GetCustomAttributes(typeof(GeneratedCodeAttribute), false)
+                .OfType<GeneratedCodeAttribute>().FirstOrDefault();
+
+            if (attribute != null)
+            {
+                if (attribute.Tool == "T4MVC")
+                    return true;
+            }
+
+            if (t.IsNested)
+            {
+                var parent = t.DeclaringType;
+                if (parent != null)
+                    return parent.IsT4MVC();
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
We have a method on init that goes through all of our classes and generates dependency injection references in Unity for them all. Because we know that the T4MVC generated classes will never need to be instantiated we've written a helper method to identify these for the purposes of excluding them.

We thought that this code might be useful to include in the T4MVC project itself, as obviously it's not specific to our project and other people may be interested in using it.

Is it something that you'd consider including?
