### PR TITLE
Disable compiler warning about clashing Dummy classes

### DIFF
--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
@@ -156,6 +156,7 @@ namespace T4MVC
     }
 }
 
+#pragma warning disable 0436
 namespace T4MVC
 {
     [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
@@ -165,6 +166,7 @@ namespace T4MVC
         public static Dummy Instance = new Dummy();
     }
 }
+#pragma warning restore 0436
 
 [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
 internal partial class T4MVC_System_Web_Mvc_ActionResult : System.Web.Mvc.ActionResult, IT4MVCActionResult

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -102,6 +102,7 @@ namespace <#=settings.T4MVCNamespace #>
 <#} #>
 }
 
+#pragma warning disable 0436
 namespace <#=settings.T4MVCNamespace #>
 {
     [<#= GeneratedCode #>, DebuggerNonUserCode]
@@ -111,6 +112,7 @@ namespace <#=settings.T4MVCNamespace #>
         public static Dummy Instance = new Dummy();
     }
 }
+#pragma warning restore 0436
 
 <#foreach (var resultType in ResultTypes.Values) { #>
 [<#= GeneratedCode #>, DebuggerNonUserCode]


### PR DESCRIPTION
Fix for #96: disable warning about clashing Dummy classes if there are multiple MVC projects with T4MVC in one solution