### PR TITLE
Don't add empty areas to the RouteValueDictionary when constructing results.

### DIFF
--- a/T4MVCExtensions/T4Extensions.cs
+++ b/T4MVCExtensions/T4Extensions.cs
@@ -917,7 +917,10 @@ namespace System.Web.Mvc
             result.Action = action;
             result.Protocol = protocol;
             result.RouteValueDictionary = new RouteValueDictionary();
-            result.RouteValueDictionary.Add("Area", area ?? "");
+
+            if (!string.IsNullOrEmpty(area))
+                result.RouteValueDictionary.Add("Area", area);
+
             result.RouteValueDictionary.Add("Controller", controller);
             result.RouteValueDictionary.Add("Action", action);
         }

--- a/T4MVCHostMvcApp.Tests/T4MVCTest.cs
+++ b/T4MVCHostMvcApp.Tests/T4MVCTest.cs
@@ -858,7 +858,9 @@ namespace T4MVCHostMvcApp.Tests
                 action = action.ToLowerInvariant();
             }
 
-            TestRouteValue(actionResult, "area", area);
+            if (!string.IsNullOrEmpty(area))
+                TestRouteValue(actionResult, "area", area);
+
             TestRouteValue(actionResult, "controller", controller);
             TestRouteValue(actionResult, "action", action);
         }

--- a/T4MVCHostMvcApp.Tests/T4MVCTest.cs
+++ b/T4MVCHostMvcApp.Tests/T4MVCTest.cs
@@ -860,6 +860,8 @@ namespace T4MVCHostMvcApp.Tests
 
             if (!string.IsNullOrEmpty(area))
                 TestRouteValue(actionResult, "area", area);
+            else
+                TestNoRouteValue(actionResult, "area");
 
             TestRouteValue(actionResult, "controller", controller);
             TestRouteValue(actionResult, "action", action);


### PR DESCRIPTION
Resolves #28.

This addresses an issue whereby Action links/URLs generated in a controller get an empty 'Area' query parameter appended to them if there was no area specified. To resolve this, a null/empty check has been added to the `area` parameter when constructing the `RouteValueDictionary` for the link.