### PR TITLE
generate asset paths for nested project items. issue #50

### DIFF
--- a/T4MVCHostMvcApp/Content/Less.css
+++ b/T4MVCHostMvcApp/Content/Less.css
@@ -1,0 +1,3 @@
+﻿h1 {
+  font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
+}

--- a/T4MVCHostMvcApp/Content/Less.less
+++ b/T4MVCHostMvcApp/Content/Less.less
@@ -1,0 +1,3 @@
+﻿h1 {
+    font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
+}

--- a/T4MVCHostMvcApp/Content/Less.min.css
+++ b/T4MVCHostMvcApp/Content/Less.min.css
@@ -1,0 +1,1 @@
+﻿h1{font-family:'Franklin Gothic Medium','Arial Narrow',Arial,sans-serif;}

--- a/T4MVCHostMvcApp/Content/SASS.css
+++ b/T4MVCHostMvcApp/Content/SASS.css
@@ -1,0 +1,3 @@
+﻿h1 {
+  font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif; }
+

--- a/T4MVCHostMvcApp/Content/SASS.min.css
+++ b/T4MVCHostMvcApp/Content/SASS.min.css
@@ -1,0 +1,1 @@
+﻿h1{font-family:'Franklin Gothic Medium','Arial Narrow',Arial,sans-serif;}

--- a/T4MVCHostMvcApp/Content/SASS.scss
+++ b/T4MVCHostMvcApp/Content/SASS.scss
@@ -1,0 +1,3 @@
+﻿h1 {
+    font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
+}

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.cs
@@ -379,6 +379,12 @@ namespace Links
         public static readonly string Hello_World_txt = Url("Hello World.txt");
         public static readonly string Hello_World_txt_ = Url("Hello$World.txt");
         public static readonly string Hello_World_txt__ = Url("Hello+World.txt");
+        public static readonly string Less_less = Url("Less.less");
+        public static readonly string Less_css = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(UrlPath + "/Less.min.css") ? Url("Less.min.css") : Url("Less.css");
+        public static readonly string Less_min_css = Url("Less.min.css");
+        public static readonly string SASS_scss = Url("SASS.scss");
+        public static readonly string SASS_css = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(UrlPath + "/SASS.min.css") ? Url("SASS.min.css") : Url("SASS.css");
+        public static readonly string SASS_min_css = Url("SASS.min.css");
         public static readonly string Site_css = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(UrlPath + "/Site.min.css") ? Url("Site.min.css") : Url("Site.css");
         [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
         public static class SomeRandomName {
@@ -735,6 +741,10 @@ namespace Links
             }
             public static class Assets
             {
+                public static readonly string Less_css_ = T4MVCHelpers.ProcessAssetPath("~/Content/Less.css");
+                public static readonly string Less_min_css_ = T4MVCHelpers.ProcessAssetPath("~/Content/Less.min.css");
+                public static readonly string SASS_css_ = T4MVCHelpers.ProcessAssetPath("~/Content/SASS.css");
+                public static readonly string SASS_min_css_ = T4MVCHelpers.ProcessAssetPath("~/Content/SASS.min.css");
                 public static readonly string Site_css = T4MVCHelpers.ProcessAssetPath("~/Content/Site.css");
                 public static readonly string StyleSheet_css = T4MVCHelpers.ProcessAssetPath("~/Content/StyleSheet.css");
                 public static readonly string StyleSheet_min_css = T4MVCHelpers.ProcessAssetPath("~/Content/StyleSheet.min.css");

--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -1141,7 +1141,8 @@ void ProcessBundleFilesRecursive(ProjectItem projectItem, string path)
 void ProcessBundleFilesRecursive(ProjectItem projectItem, string path, HashSet<String> nameSet)
 {
     // The passed in HashSet is to guarantee uniqueness with our parent and siblings
-    string name = SanitizeWithNoConflicts(projectItem.Name, nameSet);
+    string projectItemName = projectItem.Name;
+    string name = SanitizeWithNoConflicts(projectItemName, nameSet);
 
     // This HashSet is to guarantee uniqueness of our direct children
     // We add our own name to it to avoid class name conflicts (http://mvccontrib.codeplex.com/workitem/7153)
@@ -1166,22 +1167,34 @@ public static partial class <#=EscapeID(name)#>
             {
                 ProcessBundleFilesRecursive(
                     item,
-                    path + "/" + projectItem.Name,
+                    path + "/" + projectItemName,
                     childrenNameSet);
             }
 
             if (IsFile(item))
             {
-                files.Add(item);
+                AddItemRecursive(files, item);
             }
         }
 
-        BuildBundleConstants(files, path + "/" + projectItem.Name, childrenNameSet);
+        BuildBundleConstants(files, path + "/" + projectItemName, childrenNameSet);
 #>
 }
 <#+
         PopIndent();
     }    
+}
+
+void AddItemRecursive(List<ProjectItem> files, ProjectItem item)
+{
+    files.Add(item);
+    if (item.ProjectItems.Count > 0)
+    {
+        foreach (ProjectItem subItem in item.ProjectItems)
+        {
+            AddItemRecursive(files, subItem);
+        }
+    }
 }
 
 void BuildBundleConstants(List<ProjectItem> projectItems, string path, HashSet<String> childrenNameSet)

--- a/T4MVCHostMvcApp/T4MVCHostMvcApp.csproj
+++ b/T4MVCHostMvcApp/T4MVCHostMvcApp.csproj
@@ -174,7 +174,23 @@
       <SubType>Designer</SubType>
     </CodeAnalysisDictionary>
     <Content Include="Areas\Home\Views\Home\EditorTemplates\SomeAreaEditorTemplate.ascx" />
+    <None Include="compilerconfig.json" />
+    <None Include="compilerconfig.json.defaults">
+      <DependentUpon>compilerconfig.json</DependentUpon>
+    </None>
     <None Include="Content\FileWithNoExtension" />
+    <Content Include="Content\Less.css">
+      <DependentUpon>Less.less</DependentUpon>
+    </Content>
+    <Content Include="Content\Less.min.css">
+      <DependentUpon>Less.css</DependentUpon>
+    </Content>
+    <Content Include="Content\SASS.css">
+      <DependentUpon>SASS.scss</DependentUpon>
+    </Content>
+    <Content Include="Content\SASS.min.css">
+      <DependentUpon>SASS.css</DependentUpon>
+    </Content>
     <Content Include="Content\StyleSheet.min.css" />
     <Content Include="Content\SomeRandomName\SomeRandomName\SomeRandomName.txt" />
     <Content Include="Content\StyleSheet.css" />
@@ -191,6 +207,8 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="Content\SASS.scss" />
+    <Content Include="Content\Less.less" />
     <None Include="T4MVC Files\T4MVC.tt.settings.xml">
       <SubType>Designer</SubType>
     </None>

--- a/T4MVCHostMvcApp/compilerconfig.json
+++ b/T4MVCHostMvcApp/compilerconfig.json
@@ -1,0 +1,10 @@
+﻿[
+  {
+    "outputFile": "Content/SASS.css",
+    "inputFile": "Content/SASS.scss"
+  },
+  {
+    "outputFile": "Content/Less.css",
+    "inputFile": "Content/Less.less"
+  }
+]

--- a/T4MVCHostMvcApp/compilerconfig.json.defaults
+++ b/T4MVCHostMvcApp/compilerconfig.json.defaults
@@ -1,0 +1,49 @@
+{
+  "compilers": {
+    "less": {
+      "autoPrefix": "",
+      "cssComb": "none",
+      "ieCompat": true,
+      "strictMath": false,
+      "strictUnits": false,
+      "relativeUrls": true,
+      "rootPath": "",
+      "sourceMapRoot": "",
+      "sourceMapBasePath": "",
+      "sourceMap": false
+    },
+    "sass": {
+      "includePath": "",
+      "indentType": "space",
+      "indentWidth": 2,
+      "outputStyle": "nested",
+      "Precision": 5,
+      "relativeUrls": true,
+      "sourceMapRoot": "",
+      "sourceMap": false
+    },
+    "stylus": {
+      "sourceMap": false
+    },
+    "babel": {
+      "sourceMap": false
+    },
+    "coffeescript": {
+      "bare": false,
+      "runtimeMode": "node",
+      "sourceMap": false
+    }
+  },
+  "minifiers": {
+    "css": {
+      "enabled": true,
+      "termSemicolons": true,
+      "gzip": false
+    },
+    "javascript": {
+      "enabled": true,
+      "termSemicolons": true,
+      "gzip": false
+    }
+  }
+}


### PR DESCRIPTION
This change will cause assets for common types of transpiled artifacts to get asset paths generated by T4MVC. Two examples of this are the way that Web Essentials generates SASS and LESS files (examples of these were added to T4MVCHostMvcApp).  Previously nested file items were skipped because they were children of a ProjectItem that represented a file.

This change assumes all descendents of file ProjectItem are also files and adds them to the list of candidate assets, which is later filtered and generated as it previously was.