### PR TITLE
Move DebuggerNonUserCode so that it doesn't apply to the whole class

### DIFF
--- a/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
+++ b/T4MVCHostMvcApp/T4MVC Files/T4MVC.tt
@@ -175,9 +175,10 @@ RenderAdditionalCode();
 <#manager.StartNewFile(controller.GeneratedFileName); #>
 namespace <#=controller.Namespace #>
 {
-    [<#= GeneratedCode #>, DebuggerNonUserCode]
+    [<#= GeneratedCode #>]
     public partial class <#=controller.ClassName #>
     {
+        [DebuggerNonUserCode]
         protected <#=controller.ClassName #>() { }
     }
 }


### PR DESCRIPTION
We came across this issue today: this attribute is applied to the whole class, not just the parts of it that are in this file. That meant that any other methods that were in this class were not debuggable.

Moving the attribute so that it only applies to the method in this file fixes the problem.